### PR TITLE
feat(ui): compact premium redesign — cost-first ledger UI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ dist-ssr
 *.sw?
 
 # AI
+.superpowers/**
 .opencode/**
 AGENTS.md
 .agents/**

--- a/index.html
+++ b/index.html
@@ -2,11 +2,10 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+    <link rel="icon" type="image/svg+xml" href="/tauri.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Tauri + Vue + Typescript App</title>
+    <title>AI Tracker</title>
   </head>
-
   <body>
     <div id="app"></div>
     <script type="module" src="/src/main.ts"></script>

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "dev": "vite",
     "build": "vue-tsc --noEmit && vite build",
     "preview": "vite preview",
+    "test": "vitest run",
     "tauri": "tauri"
   },
   "dependencies": {
@@ -20,8 +21,11 @@
   "devDependencies": {
     "@tauri-apps/cli": "^2",
     "@vitejs/plugin-vue": "^5.2.1",
+    "@vue/test-utils": "^2.4.10",
+    "jsdom": "^29.1.1",
     "typescript": "~5.6.2",
     "vite": "^6.0.3",
+    "vitest": "^4.1.5",
     "vue-tsc": "^2.1.10"
   }
 }

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,12 +1,6 @@
 <script setup lang="ts">
 import { computed, onMounted } from "vue";
-import AppSidebar from "./components/dashboard/AppSidebar.vue";
 import HeroMetrics from "./components/dashboard/HeroMetrics.vue";
-import AnthropicSetupPanel from "./components/dashboard/AnthropicSetupPanel.vue";
-import OpenAiSetupPanel from "./components/dashboard/OpenAiSetupPanel.vue";
-import ProviderGrid from "./components/dashboard/ProviderGrid.vue";
-import SyncTimeline from "./components/dashboard/SyncTimeline.vue";
-import UsagePanel from "./components/dashboard/UsagePanel.vue";
 import { useDashboardData } from "./composables/useDashboardData";
 
 const dashboard = useDashboardData();
@@ -19,31 +13,32 @@ onMounted(() => {
 </script>
 
 <template>
-  <div class="min-h-dvh bg-slate-950 text-slate-100">
-    <div class="grid min-h-dvh lg:grid-cols-[280px_1fr]">
-      <AppSidebar :connected-count="dashboard.connectedProviders.value.length" :provider-count="providerCount" />
+  <div class="min-h-dvh bg-ledger-paper text-ledger-ink">
+    <div class="mx-auto min-h-dvh w-full max-w-[760px] px-3 py-3 sm:px-4">
+      <main class="flex flex-col gap-3" aria-label="AI usage dashboard">
+        <HeroMetrics
+          :daily-tokens="dashboard.totalDailyTokens.value"
+          :weekly-tokens="dashboard.totalWeeklyTokens.value"
+          :total-cost="dashboard.totalCost.value"
+          :connected-count="dashboard.connectedProviders.value.length"
+          :provider-count="providerCount"
+          :is-loading="dashboard.isLoading.value"
+          @sync="dashboard.syncNow"
+        />
 
-      <main class="min-w-0 px-4 py-4 md:px-6 lg:px-8" aria-label="AI usage dashboard">
-        <div class="mx-auto flex max-w-7xl flex-col gap-5">
-          <HeroMetrics
-            :daily-tokens="dashboard.totalDailyTokens.value"
-            :weekly-tokens="dashboard.totalWeeklyTokens.value"
-            :total-cost="dashboard.totalCost.value"
-            :is-loading="dashboard.isLoading.value"
-            @sync="dashboard.syncNow"
-          />
 
-          <p v-if="dashboard.errorMessage.value" class="rounded-2xl border border-red-400/30 bg-red-400/10 px-4 py-3 text-sm text-red-100" role="alert">
-            {{ dashboard.errorMessage.value }}
-          </p>
+        <p v-if="dashboard.errorMessage.value" class="rounded-2xl border border-red-300 bg-red-50 px-4 py-3 text-sm text-red-800" role="alert">
+          {{ dashboard.errorMessage.value }}
+        </p>
 
-          <ProviderGrid :providers="dashboard.snapshot.value.providers" />
+        <ProviderGrid :providers="dashboard.snapshot.value.providers" />
 
-          <div class="grid gap-5 xl:grid-cols-[1fr_380px]">
-            <UsagePanel :history="dashboard.snapshot.value.history" />
-            <SyncTimeline :events="dashboard.snapshot.value.syncEvents" />
-          </div>
+        <div class="grid gap-3 md:grid-cols-[1fr_280px]">
+          <UsagePanel :history="dashboard.snapshot.value.history" />
+          <SyncTimeline :events="dashboard.snapshot.value.syncEvents" />
+        </div>
 
+        <div class="grid gap-3 md:grid-cols-2">
           <OpenAiSetupPanel @updated="dashboard.refresh" />
           <AnthropicSetupPanel @updated="dashboard.refresh" />
         </div>

--- a/src/assets/main.css
+++ b/src/assets/main.css
@@ -1,17 +1,26 @@
-@import url("https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500;600;700&family=Fira+Sans:wght@300;400;500;600;700&display=swap");
 @import "tailwindcss";
 
 @theme {
-  --font-sans: "Fira Sans", ui-sans-serif, system-ui, sans-serif;
-  --font-mono: "Fira Code", ui-monospace, SFMono-Regular, Menlo, monospace;
+  --font-sans: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  --font-mono: "SFMono-Regular", "Cascadia Code", "Fira Code", ui-monospace, Menlo, monospace;
+  --color-ledger-paper: oklch(95.6% 0.018 85);
+  --color-ledger-panel: oklch(91.8% 0.02 82);
+  --color-ledger-inset: oklch(88.2% 0.019 82);
+  --color-ledger-ink: oklch(23.8% 0.018 72);
+  --color-ledger-muted: oklch(52.6% 0.02 74);
+  --color-ledger-line: oklch(78% 0.02 78);
+  --color-ledger-brass: oklch(70% 0.1 84);
+  --color-ledger-brass-soft: oklch(84% 0.06 86);
+  --color-ledger-graphite: oklch(18.8% 0.016 74);
+  --color-ledger-graphite-soft: oklch(27% 0.014 74);
 }
 
 @layer base {
   :root {
-    color-scheme: dark;
+    color-scheme: light;
     font-family: var(--font-sans);
-    background: #020617;
-    color: #e2e8f0;
+    background: oklch(95.6% 0.018 85);
+    color: oklch(23.8% 0.018 72);
     font-synthesis: none;
     text-rendering: optimizeLegibility;
     -webkit-font-smoothing: antialiased;
@@ -34,8 +43,9 @@
   }
 
   button:focus-visible,
-  a:focus-visible {
-    outline: 2px solid #f59e0b;
+  a:focus-visible,
+  input:focus-visible {
+    outline: 2px solid oklch(70% 0.1 84);
     outline-offset: 3px;
   }
 }

--- a/src/lib/providerPresentation.test.ts
+++ b/src/lib/providerPresentation.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+import { clampUsagePercent, confidenceLabel, getProviderLogo, sourceLabel, statusLabel } from "./providerPresentation";
+
+describe("providerPresentation", () => {
+  it("clamps usage strip values into a visible safe range", () => {
+    expect(clampUsagePercent(null)).toBe(8);
+    expect(clampUsagePercent(Number.NaN)).toBe(8);
+    expect(clampUsagePercent(2)).toBe(8);
+    expect(clampUsagePercent(42.4)).toBe(42);
+    expect(clampUsagePercent(140)).toBe(100);
+  });
+
+  it("returns provider logo metadata and fallback identity", () => {
+    expect(getProviderLogo("anthropic")).toMatchObject({ src: "/provider-logos/anthropic.svg", label: "Anthropic" });
+    expect(getProviderLogo("openai")).toMatchObject({ src: null, initials: "OA", label: "OpenAI" });
+  });
+
+  it("keeps source, confidence, and status labels explicit", () => {
+    expect(sourceLabel("official_api")).toBe("Official API");
+    expect(sourceLabel("local_estimate")).toBe("Local estimate");
+    expect(confidenceLabel("low")).toBe("Low");
+    expect(statusLabel("needs_credentials")).toBe("Needs credentials");
+  });
+});

--- a/src/lib/providerPresentation.ts
+++ b/src/lib/providerPresentation.ts
@@ -1,0 +1,63 @@
+import type { Confidence, ProviderId, ProviderStatus, UsageSource } from "../types/usage";
+
+interface ProviderLogo {
+  readonly src: string | null;
+  readonly initials: string;
+  readonly label: string;
+}
+
+const providerLogos = {
+  openai: { src: null, initials: "OA", label: "OpenAI" },
+  anthropic: { src: "/provider-logos/anthropic.svg", initials: "A", label: "Anthropic" },
+  gemini: { src: "/provider-logos/google-gemini.svg", initials: "G", label: "Google Gemini" },
+  github_copilot: { src: "/provider-logos/github-copilot.svg", initials: "GH", label: "GitHub Copilot" },
+  opencode: { src: null, initials: "OC", label: "Opencode" },
+  kimi: { src: null, initials: "K", label: "Kimi" },
+  minimax: { src: "/provider-logos/minimax.svg", initials: "MM", label: "MiniMax" },
+  glm: { src: null, initials: "GL", label: "GLM" },
+  cursor: { src: "/provider-logos/cursor.svg", initials: "C", label: "Cursor" },
+} satisfies Record<ProviderId, ProviderLogo>;
+
+export function getProviderLogo(providerId: ProviderId): ProviderLogo {
+  return providerLogos[providerId];
+}
+
+export function clampUsagePercent(value: number | null | undefined): number {
+  if (value == null || Number.isNaN(value)) {
+    return 8;
+  }
+
+  return Math.min(100, Math.max(8, Math.round(value)));
+}
+
+export function sourceLabel(source: UsageSource): string {
+  const labels = {
+    official_api: "Official API",
+    local_estimate: "Local estimate",
+    manual: "Manual",
+  } satisfies Record<UsageSource, string>;
+
+  return labels[source];
+}
+
+export function confidenceLabel(confidence: Confidence): string {
+  const labels = {
+    high: "High",
+    medium: "Medium",
+    low: "Low",
+  } satisfies Record<Confidence, string>;
+
+  return labels[confidence];
+}
+
+export function statusLabel(status: ProviderStatus): string {
+  const labels = {
+    connected: "Connected",
+    needs_credentials: "Needs credentials",
+    experimental: "Experimental",
+    unsupported: "Unsupported",
+  } satisfies Record<ProviderStatus, string>;
+
+
+  return labels[status];
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -7,7 +7,12 @@ const host = process.env.TAURI_DEV_HOST;
 
 // https://vite.dev/config/
 export default defineConfig(async () => ({
-  plugins: [tailwindcss(), vue()],
+  plugins: [vue(), tailwindcss()],
+
+  test: {
+    environment: "jsdom",
+    globals: true,
+  },
 
   // Vite options tailored for Tauri development and only applied in `tauri dev` or `tauri build`
   //


### PR DESCRIPTION
## Summary
- Compact premium Cost Strip redesign: warm light ledger theme with cost-first hierarchy
- Provider cost strips with official logos (Anthropic, Gemini, GitHub Copilot, Cursor, MiniMax) and initials fallback for others
- Full English UI throughout
- Unit tests: 6 passing with Vitest
- All Vue components under 200 lines
- `.superpowers/` added to `.gitignore`

## Testing
- `pnpm test`: 6/6 passed
- `pnpm build`: clean

Closes #1