### PR TITLE
feat: fixed-size widget window like JetBrains Toolbox

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -13,8 +13,14 @@
     "windows": [
       {
         "title": "ai-tracker",
-        "width": 800,
-        "height": 600
+        "width": 960,
+        "height": 720,
+        "minWidth": 960,
+        "minHeight": 720,
+        "maxWidth": 960,
+        "maxHeight": 720,
+        "resizable": false,
+        "maximizable": false
       }
     ],
     "security": {

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,15 +1,24 @@
 <script setup lang="ts">
 import { computed, onMounted, ref } from 'vue'
+import AnthropicSetupPanel from './components/dashboard/AnthropicSetupPanel.vue'
+import HeroMetrics from './components/dashboard/HeroMetrics.vue'
+import OpenAiSetupPanel from './components/dashboard/OpenAiSetupPanel.vue'
+import ProviderGrid from './components/dashboard/ProviderGrid.vue'
+import ProviderLoginModal from './components/dashboard/ProviderLoginModal.vue'
+import SyncTimeline from './components/dashboard/SyncTimeline.vue'
+import UsagePanel from './components/dashboard/UsagePanel.vue'
 import { useDashboardData } from './composables/useDashboardData'
+import { getDashboardShellStyle } from './lib/dashboardWindow'
 import type { ProviderId } from './types/usage'
 
 const dashboard = useDashboardData()
+const dashboardShellStyle = getDashboardShellStyle()
 
-const _providerCount = computed(() => dashboard.snapshot.value.providers.length)
+const providerCount = computed(() => dashboard.snapshot.value.providers.length)
 
 const activeModal = ref<{ providerId: ProviderId; setupType: 'openai' | 'anthropic' } | null>(null)
 
-function _openModal(providerId: ProviderId) {
+function openModal(providerId: ProviderId) {
   const setupTypeMap: Record<string, 'openai' | 'anthropic'> = {
     openai: 'openai',
     anthropic: 'anthropic',
@@ -20,7 +29,7 @@ function _openModal(providerId: ProviderId) {
   }
 }
 
-function _closeModal() {
+function closeModal() {
   activeModal.value = null
 }
 
@@ -30,9 +39,12 @@ onMounted(() => {
 </script>
 
 <template>
-  <div class="min-h-dvh bg-ledger-paper text-ledger-ink">
-    <div class="mx-auto min-h-dvh w-full max-w-[760px] px-3 py-3 sm:px-4">
-      <main class="flex flex-col gap-3" aria-label="AI usage dashboard">
+  <div class="flex h-dvh w-full items-stretch justify-center overflow-hidden bg-ledger-paper p-3 text-ledger-ink">
+    <main
+      class="grid h-full w-full grid-rows-[auto_auto_minmax(0,1fr)] gap-3 overflow-hidden rounded-[2rem] border border-ledger-line bg-ledger-paper/95 p-3 shadow-[0_20px_60px_-36px_rgba(39,34,24,0.45)]"
+      :style="dashboardShellStyle"
+      aria-label="AI usage dashboard"
+    >
         <HeroMetrics
           :daily-tokens="dashboard.totalDailyTokens.value"
           :weekly-tokens="dashboard.totalWeeklyTokens.value"
@@ -47,14 +59,18 @@ onMounted(() => {
           {{ dashboard.errorMessage.value }}
         </p>
 
-        <ProviderGrid :providers="dashboard.snapshot.value.providers" @connect="openModal" />
-
-        <div class="grid gap-3 md:grid-cols-[1fr_280px]">
-          <UsagePanel :history="dashboard.snapshot.value.history" />
-          <SyncTimeline :events="dashboard.snapshot.value.syncEvents" />
+        <div class="grid min-h-0 gap-3 min-[920px]:grid-cols-[minmax(0,1.55fr)_320px]">
+          <div class="min-h-0 overflow-hidden">
+            <ProviderGrid :providers="dashboard.snapshot.value.providers" @connect="openModal" />
+          </div>
+          <div class="grid min-h-0 gap-3 min-[920px]:grid-rows-[auto_minmax(0,1fr)]">
+            <UsagePanel :history="dashboard.snapshot.value.history" />
+            <div class="min-h-0 overflow-hidden">
+              <SyncTimeline :events="dashboard.snapshot.value.syncEvents" />
+            </div>
+          </div>
         </div>
       </main>
-    </div>
 
     <ProviderLoginModal
       v-if="activeModal"

--- a/src/assets/main.css
+++ b/src/assets/main.css
@@ -33,8 +33,18 @@
 
   body {
     min-width: 320px;
-    min-height: 100vh;
     margin: 0;
+    overflow: hidden;
+  }
+
+  html,
+  body,
+  #app {
+    height: 100%;
+  }
+
+  #app {
+    width: 100%;
   }
 
   button,

--- a/src/components/dashboard/AnthropicSetupPanel.vue
+++ b/src/components/dashboard/AnthropicSetupPanel.vue
@@ -1,12 +1,8 @@
 <script setup lang="ts">
 import { invoke } from '@tauri-apps/api/core'
+import { KeyRound, RefreshCw, Shield } from 'lucide-vue-next'
 import { onMounted, reactive, shallowRef } from 'vue'
-import type {
-  AnthropicConnectionState,
-  DashboardSnapshot,
-  SaveAnthropicCredentialsInput,
-  SaveAnthropicCredentialsResult,
-} from '../../types/usage'
+import type { AnthropicConnectionState, DashboardSnapshot, SaveAnthropicCredentialsInput, SaveAnthropicCredentialsResult } from '../../types/usage'
 
 withDefaults(
   defineProps<{
@@ -41,7 +37,7 @@ async function loadConnection() {
   }
 }
 
-async function _saveCredentials() {
+async function saveCredentials() {
   isLoading.value = true
   message.value = null
   errorMessage.value = null
@@ -66,7 +62,7 @@ async function _saveCredentials() {
   }
 }
 
-async function _syncAnthropic() {
+async function syncAnthropic() {
   isLoading.value = true
   message.value = null
   errorMessage.value = null
@@ -83,9 +79,7 @@ async function _syncAnthropic() {
   }
 }
 
-onMounted(() => {
-  void loadConnection()
-})
+onMounted(() => void loadConnection())
 </script>
 
 <template>

--- a/src/components/dashboard/HeroMetrics.vue
+++ b/src/components/dashboard/HeroMetrics.vue
@@ -1,4 +1,6 @@
 <script setup lang="ts">
+import { RefreshCw } from 'lucide-vue-next'
+
 defineProps<{
   dailyTokens: number
   weeklyTokens: number
@@ -12,12 +14,12 @@ defineEmits<{
   sync: []
 }>()
 
-const _numberFormatter = new Intl.NumberFormat('es-ES')
-const _currencyFormatter = new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD' })
+const numberFormatter = new Intl.NumberFormat('es-ES')
+const currencyFormatter = new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD' })
 </script>
 
 <template>
-  <section class="rounded-[1.75rem] border border-ledger-line bg-ledger-panel p-3" id="dashboard">
+  <section class="rounded-[1.8rem] border border-ledger-line bg-ledger-panel p-4" id="dashboard">
     <div class="flex items-center justify-between gap-3 px-1">
       <div>
         <p class="font-mono text-[0.65rem] uppercase tracking-[0.2em] text-ledger-muted">local usage ledger</p>
@@ -34,21 +36,21 @@ const _currencyFormatter = new Intl.NumberFormat('en-US', { style: 'currency', c
       </button>
     </div>
 
-    <div class="mt-3 rounded-[1.4rem] border border-ledger-graphite bg-ledger-graphite p-4 text-ledger-paper">
-      <div class="flex items-start justify-between gap-4">
-        <div>
-          <p class="font-mono text-[0.65rem] uppercase tracking-[0.18em] text-ledger-brass-soft">visible cost today</p>
-          <strong class="font-mono text-4xl leading-none tracking-tight">{{ currencyFormatter.format(totalCost) }}</strong>
-        </div>
-        <div class="text-right text-xs leading-5 text-ledger-brass-soft">
-          <strong class="block font-mono text-sm text-ledger-paper">{{ numberFormatter.format(dailyTokens) }} tokens</strong>
-          {{ numberFormatter.format(weeklyTokens) }} this week
-        </div>
+    <div class="mt-3 grid gap-3 rounded-[1.4rem] border border-ledger-graphite bg-ledger-graphite p-4 text-ledger-paper sm:grid-cols-[minmax(0,1fr)_auto]">
+      <div>
+        <p class="font-mono text-[0.65rem] uppercase tracking-[0.18em] text-ledger-brass-soft">visible cost today</p>
+        <strong class="font-mono text-3xl leading-none tracking-tight sm:text-[2.15rem]">{{ currencyFormatter.format(totalCost) }}</strong>
       </div>
-      <div class="mt-4 grid h-2 grid-cols-[50%_35%_15%] overflow-hidden rounded-full bg-ledger-graphite-soft" aria-hidden="true">
-        <span class="bg-ledger-brass"></span>
-        <span class="bg-ledger-brass-soft"></span>
-        <span class="bg-ledger-muted"></span>
+      <div class="text-left text-xs leading-5 text-ledger-brass-soft sm:text-right">
+        <strong class="block font-mono text-sm text-ledger-paper">{{ numberFormatter.format(dailyTokens) }} tokens</strong>
+        {{ numberFormatter.format(weeklyTokens) }} this week
+      </div>
+      <div class="sm:col-span-2">
+        <div class="grid h-2 grid-cols-[50%_35%_15%] overflow-hidden rounded-full bg-ledger-graphite-soft" aria-hidden="true">
+          <span class="bg-ledger-brass"></span>
+          <span class="bg-ledger-brass-soft"></span>
+          <span class="bg-ledger-muted"></span>
+        </div>
       </div>
     </div>
 

--- a/src/components/dashboard/OpenAiSetupPanel.vue
+++ b/src/components/dashboard/OpenAiSetupPanel.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { invoke } from '@tauri-apps/api/core'
+import { KeyRound, Shield } from 'lucide-vue-next'
 import { computed, onMounted, reactive, shallowRef } from 'vue'
 import type {
   OpenAiConnectionState,
@@ -32,8 +33,8 @@ const isLoading = shallowRef(false)
 const message = shallowRef<string | null>(null)
 const errorMessage = shallowRef<string | null>(null)
 
-const _panelTag = computed(() => (props.isModal ? 'div' : 'section'))
-const _panelClass = computed(() =>
+const panelTag = computed(() => (props.isModal ? 'div' : 'section'))
+const panelClass = computed(() =>
   props.isModal ? 'mt-4' : 'rounded-[1.5rem] border border-ledger-line bg-ledger-panel p-4',
 )
 
@@ -49,7 +50,7 @@ async function loadConnection() {
   }
 }
 
-async function _saveCredentials() {
+async function saveCredentials() {
   isLoading.value = true
   message.value = null
   errorMessage.value = null

--- a/src/components/dashboard/ProviderGrid.vue
+++ b/src/components/dashboard/ProviderGrid.vue
@@ -1,26 +1,33 @@
 <script setup lang="ts">
+import { KeyRound } from 'lucide-vue-next'
+import {
+  clampUsagePercent,
+  getProviderLogo,
+  statusLabel,
+} from '../../lib/providerPresentation'
 import type { ProviderId, ProviderSummary } from '../../types/usage'
+import SourceIndicator from './SourceIndicator.vue'
 
 defineProps<{
   providers: readonly ProviderSummary[]
 }>()
 
-const _emit = defineEmits<{
+const emit = defineEmits<{
   connect: [providerId: ProviderId]
 }>()
 
-const _numberFormatter = new Intl.NumberFormat('es-ES')
-const _currencyFormatter = new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD' })
+const numberFormatter = new Intl.NumberFormat('es-ES')
+const currencyFormatter = new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD' })
 </script>
 
 <template>
-  <section class="rounded-[1.75rem] border border-ledger-line bg-ledger-panel p-3" id="providers" aria-label="Provider connectors">
+  <section class="flex h-full min-h-0 flex-col rounded-[1.8rem] border border-ledger-line bg-ledger-panel p-4" id="providers" aria-label="Provider connectors">
     <div class="flex items-center justify-between px-1 pb-2">
       <h2 class="text-sm font-semibold text-ledger-ink">Provider cost strips</h2>
       <span class="font-mono text-[0.65rem] uppercase tracking-[0.16em] text-ledger-muted">tokens · cost · source</span>
     </div>
 
-    <div class="divide-y divide-ledger-line/70">
+    <div class="min-h-0 divide-y divide-ledger-line/70 overflow-y-auto pr-1">
       <article v-for="provider in providers" :key="provider.id" class="grid gap-2 py-3 first:pt-2 sm:grid-cols-[150px_1fr_auto] sm:items-center">
         <div class="flex min-w-0 items-center gap-3">
           <span class="grid size-9 shrink-0 place-items-center rounded-xl border border-ledger-line bg-ledger-paper text-[0.68rem] font-bold text-ledger-ink">

--- a/src/components/dashboard/ProviderLoginModal.vue
+++ b/src/components/dashboard/ProviderLoginModal.vue
@@ -1,5 +1,8 @@
 <script setup lang="ts">
+import { X } from 'lucide-vue-next'
 import { onMounted, onUnmounted } from 'vue'
+import { getProviderLogo } from '../../lib/providerPresentation'
+import { getDashboardModalStyle } from '../../lib/dashboardWindow'
 import type { ProviderId } from '../../types/usage'
 
 type ProviderSetupType = 'openai' | 'anthropic'
@@ -14,13 +17,15 @@ const emit = defineEmits<{
   close: []
 }>()
 
+const dialogStyle = getDashboardModalStyle()
+
 function handleKeydown(event: KeyboardEvent) {
   if (event.key === 'Escape') {
     emit('close')
   }
 }
 
-function _handleBackdropClick(event: MouseEvent) {
+function handleBackdropClick(event: MouseEvent) {
   if (event.target === event.currentTarget) {
     emit('close')
   }
@@ -53,7 +58,7 @@ onUnmounted(() => {
         :aria-labelledby="`modal-title-${providerId}`"
         @click="handleBackdropClick"
       >
-        <div class="w-full max-w-md rounded-2xl border border-ledger-line bg-ledger-panel p-6 shadow-2xl">
+        <div class="w-full max-w-md overflow-y-auto rounded-2xl border border-ledger-line bg-ledger-panel p-6 shadow-2xl" :style="dialogStyle">
           <div class="mb-4 flex items-center justify-between">
             <div class="flex items-center gap-3">
               <span class="grid size-10 shrink-0 place-items-center rounded-xl border border-ledger-line bg-ledger-paper">

--- a/src/components/dashboard/SourceIndicator.vue
+++ b/src/components/dashboard/SourceIndicator.vue
@@ -1,4 +1,6 @@
 <script setup lang="ts">
+import { AlertTriangle, Clock } from 'lucide-vue-next'
+import { confidenceLabel, sourceLabel } from '../../lib/providerPresentation'
 import type { Confidence, UsageSource } from '../../types/usage'
 
 defineProps<{
@@ -8,7 +10,7 @@ defineProps<{
   isWarning?: boolean
 }>()
 
-function _formatRelativeTime(isoString: string | null): string {
+function formatRelativeTime(isoString: string | null): string {
   if (!isoString) return 'never'
   const date = new Date(isoString)
   const now = new Date()

--- a/src/components/dashboard/SyncTimeline.vue
+++ b/src/components/dashboard/SyncTimeline.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { CircleAlert, CircleCheck, Info } from 'lucide-vue-next'
 import type { SyncEvent } from '../../types/usage'
 
 defineProps<{
@@ -7,11 +8,11 @@ defineProps<{
 </script>
 
 <template>
-  <section class="rounded-[1.5rem] border border-ledger-line bg-ledger-panel p-4" aria-labelledby="sync-title">
+  <section class="flex h-full min-h-0 flex-col rounded-[1.6rem] border border-ledger-line bg-ledger-panel p-4" aria-labelledby="sync-title">
     <p class="font-mono text-[0.65rem] uppercase tracking-[0.18em] text-ledger-muted">Connector events</p>
     <h2 id="sync-title" class="text-sm font-semibold text-ledger-ink">Sync log</h2>
 
-    <ol class="mt-4 space-y-2">
+    <ol class="mt-4 min-h-0 space-y-2 overflow-y-auto pr-1">
       <li v-for="event in events" :key="`${event.providerId}-${event.at}`" class="flex gap-2 rounded-2xl bg-ledger-inset p-3">
         <CircleCheck v-if="event.status === 'success'" class="mt-0.5 text-emerald-700" :size="16" aria-hidden="true" />
         <CircleAlert v-else-if="event.status === 'error'" class="mt-0.5 text-red-700" :size="16" aria-hidden="true" />

--- a/src/components/dashboard/UsagePanel.vue
+++ b/src/components/dashboard/UsagePanel.vue
@@ -5,16 +5,16 @@ defineProps<{
   history: readonly UsagePoint[]
 }>()
 
-const _numberFormatter = new Intl.NumberFormat('es-ES', { notation: 'compact' })
+const numberFormatter = new Intl.NumberFormat('es-ES', { notation: 'compact' })
 
-function _barHeight(tokens: number, history: readonly UsagePoint[]) {
+function barHeight(tokens: number, history: readonly UsagePoint[]) {
   const maxTokens = Math.max(...history.map((point) => point.tokens), 1)
   return `${Math.max(12, Math.round((tokens / maxTokens) * 100))}%`
 }
 </script>
 
 <template>
-  <section class="rounded-[1.5rem] border border-ledger-line bg-ledger-panel p-4" aria-labelledby="usage-title">
+  <section class="rounded-[1.6rem] border border-ledger-line bg-ledger-panel p-4" aria-labelledby="usage-title">
     <div class="flex items-center justify-between gap-3">
       <div>
         <p class="font-mono text-[0.65rem] uppercase tracking-[0.18em] text-ledger-muted">7 day ledger</p>
@@ -23,9 +23,9 @@ function _barHeight(tokens: number, history: readonly UsagePoint[]) {
       <span class="rounded-full bg-ledger-inset px-2.5 py-1 text-xs text-ledger-muted">tokens</span>
     </div>
 
-    <div class="mt-4 flex h-28 items-end gap-2" role="img" aria-label="Bar chart of token usage over the last seven days">
+    <div class="mt-3 flex h-24 items-end gap-2" role="img" aria-label="Bar chart of token usage over the last seven days">
       <div v-for="point in history" :key="point.day" class="flex min-w-0 flex-1 flex-col items-center gap-2">
-        <div class="flex h-20 w-full items-end rounded-lg bg-ledger-inset p-1">
+        <div class="flex h-18 w-full items-end rounded-lg bg-ledger-inset p-1">
           <div class="w-full rounded-md bg-ledger-graphite" :style="{ height: barHeight(point.tokens, history) }"></div>
         </div>
         <div class="text-center">

--- a/src/lib/dashboardWindow.test.ts
+++ b/src/lib/dashboardWindow.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest'
+import {
+  DASHBOARD_WIDGET_WINDOW,
+  getDashboardModalStyle,
+  getDashboardShellStyle,
+} from './dashboardWindow'
+
+describe('dashboardWindow', () => {
+  it('defines a fixed widget window configuration', () => {
+    expect(DASHBOARD_WIDGET_WINDOW).toMatchObject({
+      width: 960,
+      height: 720,
+      minWidth: 960,
+      minHeight: 720,
+      maxWidth: 960,
+      maxHeight: 720,
+      resizable: false,
+      maximizable: false,
+    })
+  })
+
+  it('returns shell style capped to the widget footprint', () => {
+    expect(getDashboardShellStyle()).toEqual({
+      maxWidth: '960px',
+      maxHeight: '720px',
+    })
+  })
+
+  it('caps modal height inside the fixed dashboard viewport', () => {
+    expect(getDashboardModalStyle()).toEqual({
+      maxHeight: 'min(688px, calc(100vh - 32px))',
+    })
+  })
+})

--- a/src/lib/dashboardWindow.ts
+++ b/src/lib/dashboardWindow.ts
@@ -1,0 +1,25 @@
+export const DASHBOARD_WIDGET_WINDOW = {
+  width: 960,
+  height: 720,
+  minWidth: 960,
+  minHeight: 720,
+  maxWidth: 960,
+  maxHeight: 720,
+  resizable: false,
+  maximizable: false,
+} as const
+
+const MODAL_VIEWPORT_PADDING = 32
+
+export function getDashboardShellStyle() {
+  return {
+    maxWidth: `${DASHBOARD_WIDGET_WINDOW.width}px`,
+    maxHeight: `${DASHBOARD_WIDGET_WINDOW.height}px`,
+  } as const
+}
+
+export function getDashboardModalStyle() {
+  return {
+    maxHeight: `min(${DASHBOARD_WIDGET_WINDOW.height - MODAL_VIEWPORT_PADDING}px, calc(100vh - ${MODAL_VIEWPORT_PADDING}px))`,
+  } as const
+}


### PR DESCRIPTION
## Summary
- Configure Tauri window to fixed 960x720 (no resize, no maximize)
- Rework dashboard layout as compact widget shell with internal scroll
- Add two-column layout from 920px breakpoint
- Cap modal height to fixed viewport
- Add typed `dashboardWindow` helper with unit tests
- Fix broken Vue `script setup` bindings and missing imports across components
- Adjust typography, spacing, and surface depth for tighter widget feel

## Details
- `src-tauri/tauri.conf.json` — fixed window 960x720, no resize/maximize
- `src/App.vue` — widget shell with grid layout and capped max-width/height
- `src/assets/main.css` — full-height layout with overflow hidden
- `src/lib/dashboardWindow.ts` — typed constants and style helpers
- `src/lib/dashboardWindow.test.ts` — unit tests for widget configuration
- Various dashboard components — compacted for fixed viewport, fixed imports

Closes #8